### PR TITLE
Add user application data directory to JSON model paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ https://github.com/GuitarML/SmartGuitarAmp
 1. Download plugin (Windows 10, Ubuntu Linux) [here](https://github.com/keyth72/SmartGuitarPedal/releases)
 2. Copy to your DAW's VST directory
 3. Copy .json models from the models/ directory of this repository to the DAW's executable directory when using VST,
-   (for example: "C:\Program Files\REAPER (x64)\\*.json") or to the same directory as the SmartPedal.exe when using standalone.
+   (for example: "C:\Program Files\REAPER (x64)\\*.json") or to the same directory as the SmartPedal.exe when using standalone. You can also add the files to your user application data directory (see [Loading hardware models](#loading-hardware-models) below).
 4. As an alternative to the drop down menu, as of release v1.2 there is a "LOAD MODEL" button to select one model 
    at a time from a file select dialog. Note that the model name won't appear in the drop down, but will be loaded by the plugin.
  
@@ -48,6 +48,11 @@ Note: Make sure to build in Release mode unless actually debugging. Debug mode w
 Models are auto loaded from the working directory of the executable. When using the plugin, add the .json files to your DAW
 .exe path (for example: "C:\Program Files\REAPER (x64)"). When running the stand alone exe, put in the same directory as
 SmartPedal.exe. 
+
+Alternatively, you can add the files to your user application data directory under "GuitarML\SmartPedal", and the plugin should load them. This corresponds to:
+- Mac: `~/Library/GuitarML/SmartPedal`
+- Linux: `~/.config/GuitarML/SmartPedal`
+- Windows: `C:\Users\<username>\AppData\Roaming\GuitarML\SmartPedal`
 
 
 ## License

--- a/SmartPedal/Source/PluginEditor.cpp
+++ b/SmartPedal/Source/PluginEditor.cpp
@@ -32,7 +32,8 @@ SmartPedalAudioProcessorEditor::SmartPedalAudioProcessorEditor (SmartPedalAudioP
     modelSelect.setColour(juce::Label::textColourId, juce::Colours::black);
     int c = 1;
     for (const auto& jsonFile : processor.jsonFiles) {
-        modelSelect.addItem(jsonFile.getFileName(), c);
+        // modelSelect.addItem(jsonFile.getFileName(), c);
+        modelSelect.addItem(jsonFile.getFullPathName(), c);
         c += 1;
     }
     modelSelect.onChange = [this] {modelSelectChanged();};
@@ -178,6 +179,8 @@ void SmartPedalAudioProcessorEditor::sliderValueChanged(Slider* slider)
 
 void SmartPedalAudioProcessorEditor::modelSelectChanged()
 {
-    String selectedFile = modelSelect.getText();
-    processor.loadConfig(File(selectedFile));
+    const int selectedFileIndex = modelSelect.getSelectedItemIndex();
+    if (selectedFileIndex >= 0 && selectedFileIndex < processor.jsonFiles.size()) {
+        processor.loadConfig(processor.jsonFiles[selectedFileIndex]);
+    }
 }

--- a/SmartPedal/Source/PluginEditor.cpp
+++ b/SmartPedal/Source/PluginEditor.cpp
@@ -32,8 +32,7 @@ SmartPedalAudioProcessorEditor::SmartPedalAudioProcessorEditor (SmartPedalAudioP
     modelSelect.setColour(juce::Label::textColourId, juce::Colours::black);
     int c = 1;
     for (const auto& jsonFile : processor.jsonFiles) {
-        // modelSelect.addItem(jsonFile.getFileName(), c);
-        modelSelect.addItem(jsonFile.getFullPathName(), c);
+        modelSelect.addItem(jsonFile.getFileName(), c);
         c += 1;
     }
     modelSelect.onChange = [this] {modelSelectChanged();};

--- a/SmartPedal/Source/PluginProcessor.cpp
+++ b/SmartPedal/Source/PluginProcessor.cpp
@@ -26,7 +26,7 @@ SmartPedalAudioProcessor::SmartPedalAudioProcessor()
     
 #endif
 {
-    addDirectory(currentDirectory);
+    setupDataDirectories();
 }
 
 SmartPedalAudioProcessor::~SmartPedalAudioProcessor()
@@ -179,7 +179,30 @@ void SmartPedalAudioProcessor::setStateInformation (const void* data, int sizeIn
     // whose contents will have been created by the getStateInformation() call.
 }
 
-//void SmartPedalAudioProcessor::addDirectory(File file)
+void SmartPedalAudioProcessor::setupDataDirectories()
+{
+    // ========
+    // Current working directory
+    addDirectory(currentDirectory);
+    
+    // ========
+    // User app data directory
+    File userAppDataDirectory = File::getSpecialLocation(File::userApplicationDataDirectory).getChildFile(JucePlugin_Manufacturer).getChildFile(JucePlugin_Name);
+    File userAppDataTempFile = userAppDataDirectory.getChildFile("tmp.pdl");
+    
+    // Create (and delete) temp file if necessary, so that user doesn't have
+    // to manually create directories
+    if (!userAppDataDirectory.exists()) {
+        userAppDataTempFile.create();
+    }
+    if (userAppDataTempFile.existsAsFile()) {
+        userAppDataTempFile.deleteFile();
+    }
+    
+    // Add the directory
+    addDirectory(userAppDataDirectory);
+}
+
 void SmartPedalAudioProcessor::addDirectory(const File& file)
 {
     if (file.isDirectory())

--- a/SmartPedal/Source/PluginProcessor.h
+++ b/SmartPedal/Source/PluginProcessor.h
@@ -58,8 +58,9 @@ public:
     void getStateInformation (MemoryBlock& destData) override;
     void setStateInformation (const void* data, int sizeInBytes) override;
 
+    // Files and configuration
+    void setupDataDirectories();
     void addDirectory(const File& file);
-
     void loadConfig(File configFile);
 
     // Overdrive Pedal


### PR DESCRIPTION
This PR adds the user application data directory to the list of paths to search for when loading JSON models as dropdown choices, with the goal of addressing #3. Specifically, the plugin will search for `<userAppDataDirectory>/GuitarML/SmartPedal`, based on the plugin manufacturer and plugin name set in the project .jucer.

The plugin will automatically create (and delete) a temp file in the directory if it doesn't exist yet, so that users don't have to manually create the directory -- however, users will have to reinstantiate the plugin after adding model files to the directory for those models to show up in the dropdown.

`SmartPedalAudioProcessorEditor::modelSelectChanged()` has also been adjusted to use `selectedItemIndex` instead of `selectedText`, in order to work with paths that aren't in the current working directory.

**Potential further TODOs:**
- Add `File::commonDocumentsDirectory` as a path as well
- Add a "Re-scan models" button so users don't have to restart the plugin after copying a model over
- Create an installer and have that do the directory setup (instead of doing it in the plugin processor constructor)